### PR TITLE
label/font.cpp: Cast bearings explicitly

### DIFF
--- a/src/label/font.cpp
+++ b/src/label/font.cpp
@@ -312,10 +312,10 @@ fonts::Font::createFontAtlas(const std::string& aName) const
   Json::Value glyph;
   glyph["ascender"] = (int32_t)std::ceil(fromFP26_6(mFace->ascender));
   glyph["descender"] = (int32_t)std::ceil(fromFP26_6(mFace->descender));
-  glyph["top_height"] = maxBearingY;
-  glyph["bottom_height"] = maxNegBearingY;
+  glyph["top_height"] = (int32_t)maxBearingY;
+  glyph["bottom_height"] = (int32_t)maxNegBearingY;
   glyph["height"] = (int32_t)std::ceil(maxHeight);
-  glyph["width"] = maxAdv;
+  glyph["width"] = (int32_t)maxAdv;
   glyph["mean_width"] = (int32_t)std::ceil(meanAdv);
 
   // glyph specific info


### PR DESCRIPTION
The variables are actually `int64_t`, but I don't think this works with the Json value (I tried casting only the three implicitly casted variables to `int64_t`, as well as all variables)